### PR TITLE
chore: introduce custom error/message when header not present

### DIFF
--- a/packages/large-response-middleware/README.md
+++ b/packages/large-response-middleware/README.md
@@ -35,7 +35,7 @@ Supported Parameters:
 | thresholdError | `number` | Error threshold level (percentage of `sizeLimitInMB`), e.g: 0.90 |
 | sizeLimitInMB | `number` | Maximum allowed size limit in MB, e.g 6 |
 | outputBucket | `string` | Identifier or name of the output S3 bucket |
-| customErrorMessage | `string \| (event:APIGatewayProxyEventV2) => string ` | Custom error message to be returned when the response is too large and the client does not support large responses (no accept header). |
+| customErrorMessage | `string \| (event:APIGatewayProxyEventV2) => string ` | Custom error message to be returned when the response is too large and the client does not support large responses (no accept header) |
 | groupRequestsBy | `function - mapper` | Function to group requests, based on API Gateway event V2. Defaults to 'all' |
 
 Example Usage:

--- a/packages/large-response-middleware/README.md
+++ b/packages/large-response-middleware/README.md
@@ -7,7 +7,7 @@ Enables Lambdas to return responses larger than 6MB by offloading the content to
 - This implementation currently provides support for API Gateway with Lambda Proxy Integration only.
 - There are plans to extend this work as described here [#issue-1](https://github.com/epilot-dev/aws-lambda-utility-middlewares/issues/1)
 
-----
+---
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/epilot-dev/aws-lambda-utility-middlewares/main/packages/large-response-middleware/docs/out/architecture-1/Architecture%20-%20Sequence%20Diagram.svg" />
@@ -23,18 +23,19 @@ When a client can handle a Large Response, it must send a request with the HTTP 
 
 If the client provides the large response MIME type, the Lambda will not log an error using `Log.error`. Instead, it will rewrite the original response with a reference to the offloaded large payload. Furthermore, the rewritten response will include the HTTP header `Content-Type` with the value `application/large-response.vnd+json`.
 
-If the client does not provide the large response MIME type, the Lambda will log an error with `Log.error`, and the response will fail due to an excessively large response body.
+If the client does not provide the large response MIME type, the Lambda will log an error with `Log.error` and rewrite the original response with a custom message (can be configured) and HTTP status code 413 (Payload Too Large).
 
 ### Middleware Configuration:
 
 Supported Parameters:
 
-| Parameter       | Type                | Description                                                                  |
-| --------------- | ------------------- | ---------------------------------------------------------------------------- |
-| thresholdWarn   | `number`            | Warning threshold level (percentage of `sizeLimitInMB`), e.g: 0.80           |
-| thresholdError  | `number`            | Error threshold level (percentage of `sizeLimitInMB`), e.g: 0.90             |
-| sizeLimitInMB   | `number`            | Maximum allowed size limit in MB, e.g 6                                      |
-| outputBucket    | `string`            | Identifier or name of the output S3 bucket                                   |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| thresholdWarn | `number` | Warning threshold level (percentage of `sizeLimitInMB`), e.g: 0.80 |
+| thresholdError | `number` | Error threshold level (percentage of `sizeLimitInMB`), e.g: 0.90 |
+| sizeLimitInMB | `number` | Maximum allowed size limit in MB, e.g 6 |
+| outputBucket | `string` | Identifier or name of the output S3 bucket |
+| customErrorMessage | `string \| (event:APIGatewayProxyEventV2) => string ` | Custom error message to be returned when the response is too large and the client does not support large responses (no accept header). |
 | groupRequestsBy | `function - mapper` | Function to group requests, based on API Gateway event V2. Defaults to 'all' |
 
 Example Usage:

--- a/packages/large-response-middleware/src/index.ts
+++ b/packages/large-response-middleware/src/index.ts
@@ -200,16 +200,7 @@ function getFormattedDate() {
 }
 
 function getCustomErrorMessage(customErrorMessage: CustomErrorMessage | undefined, event: APIGatewayProxyEventV2) {
-  let message;
-
-  if (typeof customErrorMessage === 'string') {
-    message = customErrorMessage;
-  } else if (typeof customErrorMessage === 'function') {
-    message = customErrorMessage(event);
-  } else {
-    // If customErrorMessage is neither a string nor a function or is not defined, use a fallback.
-    message = customErrorMessage ?? LARGE_RESPONSE_USER_INFO;
-  }
-
-  return message;
+  return typeof customErrorMessage === 'function'
+    ? customErrorMessage(event)
+    : customErrorMessage ?? LARGE_RESPONSE_USER_INFO;
 }

--- a/packages/large-response-middleware/src/index.ts
+++ b/packages/large-response-middleware/src/index.ts
@@ -103,15 +103,14 @@ export const withLargeResponseHandler = ({
               response_size_mb: contentLengthMB.toFixed(2),
               $payload_ref,
             });
-
             response.isBase64Encoded = false;
             response.statusCode = 413;
+            const responseErrorMessage =  customErrorMessage ?? LARGE_RESPONSE_USER_INFO;
+            
             response.body = JSON.stringify({
-              message: customErrorMessage
-                ? typeof customErrorMessage === 'string'
-                  ? customErrorMessage
-                  : customErrorMessage(event)
-                : LARGE_RESPONSE_USER_INFO,
+              message: typeof responseErrorMessage === 'string'
+                  ? responseErrorMessage
+                  : customErrorMessage?.(event) || customErrorMessage,
             });
           }
         } else if (contentLengthMB > thresholdWarnInMB) {


### PR DESCRIPTION
This PR introduces a custom error message along with an explicit 413 (Payload Too Large) status code response override for scenarios where payload size exceeds the allowable limit and the requisite header is missing.

Additionally, this update provides flexibility for specifying alternative error messages in situations where the default message does not suffice. It also offers the ability to manage the payload size received by the consumer application or client independently of AWS Lambda's constraints. Currently, when payload sizes exceed AWS Lambda's limitations, we log an ERROR and allow the Lambda/API Gateway to eventually fail with a 'payload too large' error internally.

Feel free to test or let me know if we should have a different approach! 💪 

<img width="721" alt="Screenshot 2024-02-02 at 15 12 27" src="https://github.com/epilot-dev/aws-lambda-utility-middlewares/assets/53876147/a8f0f9c8-2401-47af-b3e7-9a0763ce3bac">
