### PR TITLE
fix(large-response-middleware): use Buffer.byteLength for accurate UTF-8 size measurement

### DIFF
--- a/packages/large-response-middleware/src/index.ts
+++ b/packages/large-response-middleware/src/index.ts
@@ -60,7 +60,7 @@ export const withLargeResponseHandler = ({
           : '';
         const payload = (handlerRequestContext?.response?.body ?? '') + responseHeadersString;
 
-        const aproxContentLengthBytes = payload.length * 1.0;
+        const aproxContentLengthBytes = Buffer.byteLength(payload, 'utf8');
         const contentLengthMB = aproxContentLengthBytes > 0 ? aproxContentLengthBytes / TO_MB_FACTOR : 0.0;
         const sizeLimitInMB = (_sizeLimitInMB ?? LIMIT_REQUEST_SIZE_MB) * 1.0;
         const thresholdWarnInMB = (thresholdWarn ?? 0.0) * 1.0 * sizeLimitInMB;

--- a/packages/large-response-middleware/tsconfig.json
+++ b/packages/large-response-middleware/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "lib": ["ESNext"],
     "sourceMap": true,
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "node"],
     "strict": true,
     "strictFunctionTypes": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Summary
- Replace `payload.length * 1.0` with `Buffer.byteLength(payload, 'utf8')` for accurate byte counting
- Add `node` to `tsconfig.json` types so `Buffer` resolves without a TS error

## Problem
`String.prototype.length` counts JavaScript UTF-16 code units, not bytes. For responses containing multi-byte UTF-8 characters the middleware was significantly underestimating the actual payload size, causing it to miss the error threshold and pass an oversized response to the Lambda runtime — which then hard-rejected it with:
```
LAMBDA_RUNTIME Failed to post handler success response. Http response code: 413.
{"errorMessage":"Exceeded maximum allowed payload size (6291556 bytes)."}
```
This meant the client received a 413 even when it had correctly sent `Accept: application/large-response.vnd+json`.

## Test plan
- [x] All 8 existing tests pass (`npm test`)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Sonnet 4.6](https://claude.ai/claude-code)